### PR TITLE
Pin SHA1 GHA

### DIFF
--- a/.github/workflows/app-auth-test.yml
+++ b/.github/workflows/app-auth-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     name: GitHub App authentication test (client 1)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up mutex with GitHub App
         uses: ./
         with:
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     name: GitHub App authentication test (client 2)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: |
           echo "Simulated concurrent client acquiring lock with GitHub App auth. Waiting for 5 seconds to let the first client acquire the lock..."
           sleep 5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Simple mutex test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up mutex
         uses: ./
       - run: |
@@ -26,7 +26,7 @@ jobs:
     name: Two clients test (client 1)
     needs: [simple_test]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up mutex
         uses: ./
         with:
@@ -41,7 +41,7 @@ jobs:
     name: Two clients test (client 2)
     needs: [simple_test]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up mutex
         uses: ./
         with:
@@ -56,7 +56,7 @@ jobs:
     name: Test the debug flag
     needs: [simple_test]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up mutex
         uses: ./
         with:
@@ -70,7 +70,7 @@ jobs:
     name: Mutex test with custom lock and skip post-execution
     needs: [simple_test]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up mutex
         uses: ./
         with:
@@ -86,7 +86,7 @@ jobs:
     name: Test unlocking a custom lock
     needs: [simple_test_custom_lock]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Release up mutex
         uses: ./
         with:

--- a/.github/workflows/token-auth-test.yml
+++ b/.github/workflows/token-auth-test.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Mutex test with GitHub Token authentication
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Generate Github Token
         id: app-token
-        uses: actions/create-github-app-token@v3.0.0
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ vars.GHAPP_NUCLIA_SERVICE_BOT_ID }}
           private-key: ${{ secrets.GHAPP_NUCLIA_SERVICE_BOT_PK }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use specific commit SHAs for the `actions/checkout` and `actions/create-github-app-token` actions instead of version tags. This change improves security and reproducibility by ensuring that workflows always use the exact same version of each action, avoiding unexpected changes from upstream updates.

Dependency pinning for workflow actions:

* Updated all uses of `actions/checkout@v6` to reference the specific commit SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) in `.github/workflows/main.yml`, `.github/workflows/app-auth-test.yml`, and `.github/workflows/token-auth-test.yml`. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L17-R17) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L29-R29) [[3]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L44-R44) [[4]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L59-R59) [[5]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L73-R73) [[6]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L89-R89) [[7]](diffhunk://#diff-5d84c209ac497f385893193c59dcc0bf477d4da2631a0bf11d7a3f8650988b82L21-R21) [[8]](diffhunk://#diff-5d84c209ac497f385893193c59dcc0bf477d4da2631a0bf11d7a3f8650988b82L39-R39) [[9]](diffhunk://#diff-eabcccd1fd3e701345305d58bc80ee04e9954300ee33cdec0ead7be54a79c350L21-R24)
* Updated `actions/create-github-app-token@v3.0.0` to use the specific commit SHA `f8d387b68d61c58ab83c6c016672934102569859` in `.github/workflows/token-auth-test.yml`.