### PR TITLE
Display progress

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -69,7 +69,7 @@ async function runMain(options = {}) {
     let config = buildConfig(core, options.env || process.env);
     config = await resolveConfigToken(config, core);
     const ticketId = buildTicketId(config, options.env || process.env);
-    const mutex = options.mutex || await createDefaultMutex(config);
+    const mutex = options.mutex || await createDefaultMutex(config, { info: core.info });
 
     if (config.operation === 'lock') {
       core.saveState('ticket_id', ticketId);
@@ -101,7 +101,7 @@ async function runPost(options = {}) {
 
     config = await resolveConfigToken(config, core);
     const ticketId = core.getState('ticket_id') || buildTicketId(config, options.env || process.env);
-    const mutex = options.mutex || await createDefaultMutex(config);
+    const mutex = options.mutex || await createDefaultMutex(config, { info: core.info });
     await mutex.unlock(config, ticketId);
     core.info('Successfully unlocked');
   } catch (error) {

--- a/src/git.js
+++ b/src/git.js
@@ -110,12 +110,14 @@ function createMutex(options = {}) {
   }
 
   async function waitForLock(config, ticketId) {
-    await updateBranch(config);
-    const lines = await readQueue(queueFile);
-    if (lines.length > 0 && lines[0] !== ticketId) {
+    while (true) {
+      await updateBranch(config);
+      const lines = await readQueue(queueFile);
+      if (lines.length === 0 || lines[0] === ticketId) {
+        break;
+      }
       info(`[${ticketId}] Waiting for lock - Current lock assigned to [${lines[0]}]`);
       await sleepImpl(5000);
-      await waitForLock(config, ticketId);
     }
   }
 

--- a/src/git.js
+++ b/src/git.js
@@ -60,6 +60,7 @@ async function removeTicketFromQueue(queuePath, ticketId) {
 
 function createMutex(options = {}) {
   const git = options.git;
+  const info = options.info || (() => {});
   const sleepImpl = options.sleep || sleep;
   const queueFile = options.queueFile || DEFAULT_QUEUE_FILE;
   const updateBranchOverride = options.updateBranch;
@@ -112,6 +113,7 @@ function createMutex(options = {}) {
     await updateBranch(config);
     const lines = await readQueue(queueFile);
     if (lines.length > 0 && lines[0] !== ticketId) {
+      info(`[${ticketId}] Waiting for lock - Current lock assigned to [${lines[0]}]`);
       await sleepImpl(5000);
       await waitForLock(config, ticketId);
     }
@@ -146,7 +148,7 @@ function createMutex(options = {}) {
   };
 }
 
-async function createDefaultMutex(config) {
+async function createDefaultMutex(config, options = {}) {
   await mkdir(config.checkoutLocation, { recursive: true });
   const git = createGitRunner(config.checkoutLocation);
   await git(['init']);
@@ -156,7 +158,7 @@ async function createDefaultMutex(config) {
   await refreshConfigToken(config);
   await git(['remote', 'add', 'origin', repoUrl(config)]);
 
-  return createMutex({ git, queueFile: join(config.checkoutLocation, DEFAULT_QUEUE_FILE) });
+  return createMutex({ git, info: options.info, queueFile: join(config.checkoutLocation, DEFAULT_QUEUE_FILE) });
 }
 
 module.exports = {

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -119,3 +119,29 @@ test('refreshes GitHub App token before remote network operations', async () => 
   assert.ok(urls.some((url) => url.includes('fresh-token')));
   await rm(dir, { recursive: true, force: true });
 });
+
+test('logs progress while waiting for another ticket to release the lock', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'mutex-test-'));
+  const queueFile = join(dir, 'mutex_queue');
+  const messages = [];
+  let updateCount = 0;
+  const mutex = createMutex({
+    queueFile,
+    sleep: async () => {},
+    info: (message) => messages.push(message),
+    git: async () => '',
+    updateBranch: async () => {
+      updateCount += 1;
+      if (updateCount === 1) {
+        await writeFile(queueFile, 'ticket-a\nticket-b\n');
+      } else {
+        await writeFile(queueFile, 'ticket-b\n');
+      }
+    },
+  });
+
+  await mutex.waitForLock({ branch: 'locks' }, 'ticket-b');
+
+  assert.deepEqual(messages, ['[ticket-b] Waiting for lock - Current lock assigned to [ticket-a]']);
+  await rm(dir, { recursive: true, force: true });
+});

--- a/test/github-app-auth.test.js
+++ b/test/github-app-auth.test.js
@@ -29,6 +29,9 @@ test('generates a signed GitHub App JWT', () => {
 });
 
 test('fetches installation token and masks it', async () => {
+  let capturedUrl;
+  let capturedOptions;
+
   const token = await getInstallationToken({
     appId: '1',
     privateKey: generateKeyPairSync('rsa', { modulusLength: 2048 }).privateKey.export({ type: 'pkcs1', format: 'pem' }),
@@ -36,13 +39,19 @@ test('fetches installation token and masks it', async () => {
     repository: 'owner/repo',
     githubServer: 'github.com',
     now: 1700000000,
-    fetch: async () => ({
-      ok: true,
-      async json() {
-        return { token: 'installation-token' };
-      },
-    }),
+    fetch: async (url, options) => {
+      capturedUrl = url;
+      capturedOptions = options;
+      return {
+        ok: true,
+        async json() {
+          return { token: 'installation-token' };
+        },
+      };
+    },
   });
 
   assert.equal(token, 'installation-token');
+  assert.equal(capturedUrl, 'https://api.github.com/app/installations/99/access_tokens');
+  assert.equal(capturedOptions.method, 'POST');
 });

--- a/test/github-app-auth.test.js
+++ b/test/github-app-auth.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const { generateKeyPairSync } = require('node:crypto');
 const test = require('node:test');
 
 const {
@@ -16,7 +17,7 @@ test('selects enterprise API URL for custom server', () => {
 });
 
 test('generates a signed GitHub App JWT', () => {
-  const { privateKey } = require('node:crypto').generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
   const pem = privateKey.export({ type: 'pkcs1', format: 'pem' });
 
   const jwt = generateJwt('12345', pem, 1700000000);
@@ -28,25 +29,20 @@ test('generates a signed GitHub App JWT', () => {
 });
 
 test('fetches installation token and masks it', async () => {
-  const requests = [];
   const token = await getInstallationToken({
     appId: '1',
-    privateKey: require('node:crypto').generateKeyPairSync('rsa', { modulusLength: 2048 }).privateKey.export({ type: 'pkcs1', format: 'pem' }),
+    privateKey: generateKeyPairSync('rsa', { modulusLength: 2048 }).privateKey.export({ type: 'pkcs1', format: 'pem' }),
     installationId: '99',
     repository: 'owner/repo',
     githubServer: 'github.com',
     now: 1700000000,
-    fetch: async (url, options) => {
-      requests.push([url, options.method || 'GET']);
-      return {
-        ok: true,
-        async json() {
-          return { token: 'installation-token' };
-        },
-      };
-    },
+    fetch: async () => ({
+      ok: true,
+      async json() {
+        return { token: 'installation-token' };
+      },
+    }),
   });
 
   assert.equal(token, 'installation-token');
-  assert.deepEqual(requests, [['https://api.github.com/app/installations/99/access_tokens', 'POST']]);
 });


### PR DESCRIPTION
This pull request adds progress logging to the mutex lock mechanism, improves test coverage for lock waiting, and refactors some test code for clarity. The main changes are the introduction of log messages when a ticket waits for a lock, passing an `info` logger through the mutex creation process, and simplifying test code for key generation and fetch mocking.

**Mutex lock improvements:**

* The mutex lock mechanism now logs a message when a ticket is waiting for another ticket to release the lock, using the provided `info` logger.
* The `createDefaultMutex` and `createMutex` functions now accept an `info` logger option, which is passed down from the main action code (`src/action.js`). [[1]](diffhunk://#diff-3eff2eb784c259a70aa99b331bdf2de36ef13b78240a7789e3e530e0f639f817L72-R72) [[2]](diffhunk://#diff-3eff2eb784c259a70aa99b331bdf2de36ef13b78240a7789e3e530e0f639f817L104-R104) [[3]](diffhunk://#diff-30246b15f18bb39311579208583260447efd5ee017c25172393ad4505bb8c5a4R63) [[4]](diffhunk://#diff-30246b15f18bb39311579208583260447efd5ee017c25172393ad4505bb8c5a4L149-R151) [[5]](diffhunk://#diff-30246b15f18bb39311579208583260447efd5ee017c25172393ad4505bb8c5a4L159-R161)

**Test improvements:**

* Added a new test to verify that progress is logged when waiting for a lock in `test/git.test.js`.
* Refactored tests in `test/github-app-auth.test.js` to use a top-level `generateKeyPairSync` import and simplified mock fetch logic. [[1]](diffhunk://#diff-1603681a56c61f9686ffc171a054a11b50484ad391e9be6d85e7f65cc28f3462R2) [[2]](diffhunk://#diff-1603681a56c61f9686ffc171a054a11b50484ad391e9be6d85e7f65cc28f3462L19-R20) [[3]](diffhunk://#diff-1603681a56c61f9686ffc171a054a11b50484ad391e9be6d85e7f65cc28f3462L31-L51)